### PR TITLE
bugfix/fix-channel-axis-no-label

### DIFF
--- a/napari_aicsimageio/core.py
+++ b/napari_aicsimageio/core.py
@@ -118,16 +118,20 @@ def reader_function(path: PathLike, compute: bool, processes: bool) -> List[Laye
             # No channels, always display
             visible = True
 
+        # Construct basic metadata
+        meta = {
+            "name": channel_names,
+            "visible": visible,
+        }
+
         # If multiple files were read we need to increment channel axis due to stack
         channel_axis = results[0].channel_axis
         if len(paths) > 1 and channel_axis is not None:
             channel_axis += 1
 
-        meta = {
-            "name": channel_names,
-            "channel_axis": channel_axis,
-            "visible": visible,
-        }
+        # Only add channel axis if it's not None
+        if channel_axis is not None:
+            meta["channel_axis"] = channel_axis
 
     return [(data, meta)]
 


### PR DESCRIPTION
Found during testing the full round trip of image annotation, the annotation layer was failing to load back into napari due to channel axis addition to layer metadata.