### PR TITLE
change metadata back to dict

### DIFF
--- a/napari_aicsimageio/core.py
+++ b/napari_aicsimageio/core.py
@@ -93,7 +93,7 @@ def reader_function(
 
         # Apply all other metadata
         meta_reader = partial(_get_meta, img=img)
-        meta["metadata"] = {'ome_types': meta_reader}
+        meta["metadata"] = {"ome_types": meta_reader}
 
         return [(data.data, meta, "image")]
 

--- a/napari_aicsimageio/core.py
+++ b/napari_aicsimageio/core.py
@@ -93,7 +93,7 @@ def reader_function(
 
         # Apply all other metadata
         meta_reader = partial(_get_meta, img=img)
-        meta["metadata"] = meta_reader
+        meta["metadata"] = {'ome_types': meta_reader}
 
         return [(data.data, meta, "image")]
 


### PR DESCRIPTION

hey @JacksonMaxfield ... I made a mistake in suggesting that `layer.metadata` might be made a `callable`.  That has the potential to break other plugins making assumptions about types,  see [this issue](https://forum.image.sc/t/napari-pyclesperanto-assistant-issue-in-apple-silicon-m1-arm64-native-env/55055/3) on image.sc and https://github.com/napari/napari/issues/3017.

I propose that `ome-types` will look for a key `layer.metadata['ome_types']`, which can be either an instance of `ome_types.OME` or a callable (which will be called when checking) that returns an instance.

I'll make the change in ome-types as well and cut a new release... let me know what you think 