### PR TITLE
feature/use-physical-pixel-size-for-scales

### DIFF
--- a/napari_aicsimageio/core.py
+++ b/napari_aicsimageio/core.py
@@ -84,6 +84,20 @@ def reader_function(
         if DimensionNames.Samples in img.reader.dims.order:
             meta["rgb"] = True
 
+        # Handle scales
+        scale: List[float] = []
+        for dim in img.reader.dims.order:
+            if dim in [
+                DimensionNames.SpatialX,
+                DimensionNames.SpatialY,
+                DimensionNames.SpatialZ,
+            ]:
+                scale.append(getattr(img.physical_pixel_sizes, dim))
+
+        # Apply scales
+        if len(scale) > 0:
+            meta["scale"] = tuple(scale)
+
         # Apply all other metadata
         meta["metadata"] = {"ome_types": img.metadata}
 

--- a/napari_aicsimageio/core.py
+++ b/napari_aicsimageio/core.py
@@ -92,7 +92,9 @@ def reader_function(
                 DimensionNames.SpatialY,
                 DimensionNames.SpatialZ,
             ]:
-                scale.append(getattr(img.physical_pixel_sizes, dim))
+                scale_val = getattr(img.physical_pixel_sizes, dim)
+                if scale_val is not None:
+                    scale.append(scale_val)
 
         # Apply scales
         if len(scale) > 0:

--- a/napari_aicsimageio/tests/test_core.py
+++ b/napari_aicsimageio/tests/test_core.py
@@ -36,17 +36,29 @@ CZI_FILE = "variable_scene_shape_first_scene_pyramid.czi"
         (
             CZI_FILE,
             (3, 6183, 7705),
-            {"name": ["EGFP", "mCher", "PGC"], "channel_axis": 0},
+            {
+                "name": ["EGFP", "mCher", "PGC"],
+                "channel_axis": 0,
+                "scale": (9.08210704883533, 9.08210704883533),
+            },
         ),
         (
             OME_TIFF,
             (1, 4, 65, 600, 900),
-            {"name": ["Bright_2", "EGFP", "CMDRP", "H3342"], "channel_axis": 1},
+            {
+                "name": ["Bright_2", "EGFP", "CMDRP", "H3342"],
+                "channel_axis": 1,
+                "scale": (0.29, 0.10833333333333332, 0.10833333333333332),
+            },
         ),
         (
             LIF_FILE,
             (1, 4, 1, 5622, 7666),
-            {"name": ["Gray", "Red", "Green", "Cyan"], "channel_axis": 1},
+            {
+                "name": ["Gray", "Red", "Green", "Cyan"],
+                "channel_axis": 1,
+                "scale": (4.984719055966396, 4.984719055966396),
+            },
         ),
     ],
 )


### PR DESCRIPTION
**Pull request recommendations:**
- [x] Name your pull request _your-development-type/short-description_. Ex: _feature/read-tiff-files_
- [x] Link to any relevant issue in the PR description. Ex: _Resolves [gh-12], adds tiff file format support_
- [x] Provide context of changes.

Uses the scales parameter on view image to help napari show the actual size of the pixels.

- [x] Provide relevant tests for your feature or bug fix.
- [x] Provide or update documentation for any feature added by your pull request.

Thanks for contributing!
