### PR TITLE
feature/add-scene-selection-widget

### DIFF
--- a/napari_aicsimageio/core.py
+++ b/napari_aicsimageio/core.py
@@ -4,12 +4,11 @@
 from functools import partial
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
-import xarray as xr
 import napari
-
-from qtpy.QtWidgets import QListWidget
+import xarray as xr
 from aicsimageio import AICSImage, exceptions, types
 from aicsimageio.dimensions import DimensionNames
+from qtpy.QtWidgets import QListWidget
 
 ###############################################################################
 

--- a/napari_aicsimageio/core.py
+++ b/napari_aicsimageio/core.py
@@ -51,7 +51,7 @@ def _get_scenes(img: AICSImage, in_memory: bool) -> None:
     for i, scene in enumerate(img.scenes):
         list_widget.addItem(f"{i} :: {scene}")
     viewer = napari.current_viewer()
-    viewer.window.add_dock_widget([list_widget], area="right", name="Scene Selector")
+    viewer.window.add_dock_widget(list_widget, area="right", name="Scene Selector")
 
     # Function to create image layer from a scene selected in the list widget
     def open_scene(item):

--- a/napari_aicsimageio/core.py
+++ b/napari_aicsimageio/core.py
@@ -65,18 +65,19 @@ def _get_full_image_data(img: AICSImage, in_memory: bool) -> Optional[xr.DataArr
 
 
 # Function to handle multi-scene files.
-def _get_scenes(img: AICSImage, in_memory: bool) -> Optional[xr.DataArray]:
+def _get_scenes(img: AICSImage, in_memory: bool) -> None:
     # Create the list widget and populate with the scenes in the file
     list_widget = QListWidget()
-    for scene in img.scenes:
-        list_widget.addItem(scene)
+    for i, scene in enumerate(img.scenes):
+        list_widget.addItem(f"{i} -- {scene}")
     viewer = napari.current_viewer()
     viewer.window.add_dock_widget([list_widget], area="right", name="Scene Selector")
 
     # Function to create image layer from a scene selected in the list widget
     def open_scene(item):
-        scene = item.text()
-        img.set_scene(scene)
+        scene_text = item.text()
+        scene_index = int(scene_text.split(" -- ")[0])
+        img.set_scene(scene_index)
         if DimensionNames.MosaicTile in img.reader.dims.order:
             try:
                 if in_memory:

--- a/napari_aicsimageio/core.py
+++ b/napari_aicsimageio/core.py
@@ -69,14 +69,14 @@ def _get_scenes(img: AICSImage, in_memory: bool) -> None:
     # Create the list widget and populate with the scenes in the file
     list_widget = QListWidget()
     for i, scene in enumerate(img.scenes):
-        list_widget.addItem(f"{i} -- {scene}")
+        list_widget.addItem(f"{i} :: {scene}")
     viewer = napari.current_viewer()
     viewer.window.add_dock_widget([list_widget], area="right", name="Scene Selector")
 
     # Function to create image layer from a scene selected in the list widget
     def open_scene(item):
         scene_text = item.text()
-        scene_index = int(scene_text.split(" -- ")[0])
+        scene_index = int(scene_text.split(" :: ")[0])
         img.set_scene(scene_index)
         if DimensionNames.MosaicTile in img.reader.dims.order:
             try:
@@ -97,7 +97,7 @@ def _get_scenes(img: AICSImage, in_memory: bool) -> None:
             else:
                 data = img.reader.xarray_dask_data
         meta = _get_meta(data, img)
-        viewer.add_image(data, name=scene, metadata=meta, scale=meta["scale"])
+        viewer.add_image(data, name=scene_text, metadata=meta, scale=meta["scale"])
 
     list_widget.currentItemChanged.connect(open_scene)
     return None

--- a/napari_aicsimageio/core.py
+++ b/napari_aicsimageio/core.py
@@ -2,21 +2,14 @@
 # -*- coding: utf-8 -*-
 
 from functools import partial
-from typing import Any, Callable, Dict, List, Optional, Tuple, Union
+from typing import Any, Dict, List, Optional
 
 import napari
+from napari.types import LayerData, ReaderFunction, PathLike
 import xarray as xr
-from aicsimageio import AICSImage, exceptions, types
+from aicsimageio import AICSImage, exceptions
 from aicsimageio.dimensions import DimensionNames
-from qtpy.QtWidgets import QListWidget
-
-###############################################################################
-
-LayerData = Union[Tuple[types.ArrayLike, Dict[str, Any], str]]
-PathLike = Union[str, List[str]]
-ReaderFunction = Callable[[PathLike], List[LayerData]]
-
-###############################################################################
+from qtpy.QtWidgets import QListWidget, QListWidgetItem
 
 
 def _get_full_image_data(img: AICSImage, in_memory: bool) -> Optional[xr.DataArray]:
@@ -54,7 +47,7 @@ def _get_scenes(img: AICSImage, in_memory: bool) -> None:
     viewer.window.add_dock_widget(list_widget, area="right", name="Scene Selector")
 
     # Function to create image layer from a scene selected in the list widget
-    def open_scene(item) -> None:
+    def open_scene(item: QListWidgetItem) -> None:
         scene_text = item.text()
 
         # Use scene indexes to cover for duplicate names
@@ -85,7 +78,7 @@ def _get_scenes(img: AICSImage, in_memory: bool) -> None:
 
 
 # Function to get Metadata to provide with data
-def _get_meta(data, img) -> Dict[str, Any]:
+def _get_meta(data: xr.DataArray, img: AICSImage) -> Dict[str, Any]:
     meta = {}
     if DimensionNames.Channel in data.dims:
 

--- a/napari_aicsimageio/core.py
+++ b/napari_aicsimageio/core.py
@@ -8,7 +8,9 @@ import xarray as xr
 from aicsimageio import AICSImage, exceptions, types
 from aicsimageio.dimensions import DimensionNames
 from qtpy.QtWidgets import QListWidget
-from napari import Viewer
+
+# from napari import Viewer
+import napari
 
 ###############################################################################
 
@@ -23,16 +25,16 @@ ReaderFunction = Callable[[PathLike], List[LayerData]]
 # Licensed under MIT License
 
 
-def _get_viewer() -> Optional[Viewer]:
-    import inspect
+# def _get_viewer() -> Optional[Viewer]:
+#     import inspect
 
-    frame = inspect.currentframe().f_back
-    while frame:
-        instance = frame.f_locals.get("self")
-        if instance is not None and isinstance(instance, Viewer):
-            return instance
-        frame = frame.f_back
-    return None
+#     frame = inspect.currentframe().f_back
+#     while frame:
+#         instance = frame.f_locals.get("self")
+#         if instance is not None and isinstance(instance, Viewer):
+#             return instance
+#         frame = frame.f_back
+#     return None
 
 
 ###############################################################################
@@ -68,7 +70,7 @@ def _get_scenes(img: AICSImage, in_memory: bool) -> Optional[xr.DataArray]:
     list_widget = QListWidget()
     for scene in img.scenes:
         list_widget.addItem(scene)
-    viewer = _get_viewer()
+    viewer = napari.current_viewer()
     viewer.window.add_dock_widget([list_widget], area="right", name="Scene Selector")
 
     # Function to create image layer from a scene selected in the list widget

--- a/napari_aicsimageio/core.py
+++ b/napari_aicsimageio/core.py
@@ -91,9 +91,14 @@ def _get_scenes(img: AICSImage, in_memory: bool) -> Optional[xr.DataArray]:
             else:
                 data = img.reader.xarray_dask_data
         meta = _get_meta(data, img)
-        return [(data.data, meta, "image")]
+        viewer.add_image(
+            data,
+            name=scene,
+            metadata=meta,
+        )
 
     list_widget.currentItemChanged.connect(open_scene)
+    return None
 
 
 def _get_meta(data, img):
@@ -153,6 +158,7 @@ def reader_function(
             f"Will show scenes, but load scene: '{img.current_scene}'."
         )
         _get_scenes(img, in_memory=in_memory)
+        return [(None,)]
     else:
         data = _get_full_image_data(img, in_memory=in_memory)
 

--- a/napari_aicsimageio/core.py
+++ b/napari_aicsimageio/core.py
@@ -54,7 +54,7 @@ def _get_scenes(img: AICSImage, in_memory: bool) -> None:
     viewer.window.add_dock_widget(list_widget, area="right", name="Scene Selector")
 
     # Function to create image layer from a scene selected in the list widget
-    def open_scene(item):
+    def open_scene(item) -> None:
         scene_text = item.text()
 
         # Use scene indexes to cover for duplicate names
@@ -85,7 +85,7 @@ def _get_scenes(img: AICSImage, in_memory: bool) -> None:
 
 
 # Function to get Metadata to provide with data
-def _get_meta(data, img):
+def _get_meta(data, img) -> None:
     meta = {}
     if DimensionNames.Channel in data.dims:
 

--- a/napari_aicsimageio/core.py
+++ b/napari_aicsimageio/core.py
@@ -5,10 +5,11 @@ from functools import partial
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
 import xarray as xr
+import napari
+
+from qtpy.QtWidgets import QListWidget
 from aicsimageio import AICSImage, exceptions, types
 from aicsimageio.dimensions import DimensionNames
-from qtpy.QtWidgets import QListWidget
-import napari
 
 ###############################################################################
 

--- a/napari_aicsimageio/core.py
+++ b/napari_aicsimageio/core.py
@@ -91,11 +91,7 @@ def _get_scenes(img: AICSImage, in_memory: bool) -> Optional[xr.DataArray]:
             else:
                 data = img.reader.xarray_dask_data
         meta = _get_meta(data, img)
-        viewer.add_image(
-            data,
-            name=scene,
-            metadata=meta,
-        )
+        viewer.add_image(data, name=scene, metadata=meta, scale=meta["scale"])
 
     list_widget.currentItemChanged.connect(open_scene)
     return None

--- a/napari_aicsimageio/core.py
+++ b/napari_aicsimageio/core.py
@@ -2,14 +2,16 @@
 # -*- coding: utf-8 -*-
 
 from functools import partial
-from typing import Any, Dict, List, Optional
+from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
 import napari
 import xarray as xr
 from aicsimageio import AICSImage, exceptions
 from aicsimageio.dimensions import DimensionNames
-from napari.types import LayerData, PathLike, ReaderFunction
 from qtpy.QtWidgets import QListWidget, QListWidgetItem
+
+if TYPE_CHECKING:
+    from napari.types import LayerData, PathLike, ReaderFunction
 
 
 def _get_full_image_data(img: AICSImage, in_memory: bool) -> Optional[xr.DataArray]:
@@ -117,8 +119,8 @@ def _get_meta(data: xr.DataArray, img: AICSImage) -> Dict[str, Any]:
 
 
 def reader_function(
-    path: PathLike, in_memory: bool, scene_name: Optional[str] = None
-) -> Optional[List[LayerData]]:
+    path: "PathLike", in_memory: bool, scene_name: Optional[str] = None
+) -> Optional[List["LayerData"]]:
     """
     Given a single path return a list of LayerData tuples.
     """
@@ -157,7 +159,7 @@ def reader_function(
             return [(data.data, meta, "image")]
 
 
-def get_reader(path: PathLike, in_memory: bool) -> Optional[ReaderFunction]:
+def get_reader(path: "PathLike", in_memory: bool) -> Optional["ReaderFunction"]:
     """
     Given a single path or list of paths, return the appropriate aicsimageio reader.
     """

--- a/napari_aicsimageio/core.py
+++ b/napari_aicsimageio/core.py
@@ -5,10 +5,10 @@ from functools import partial
 from typing import Any, Dict, List, Optional
 
 import napari
-from napari.types import LayerData, ReaderFunction, PathLike
 import xarray as xr
 from aicsimageio import AICSImage, exceptions
 from aicsimageio.dimensions import DimensionNames
+from napari.types import LayerData, PathLike, ReaderFunction
 from qtpy.QtWidgets import QListWidget, QListWidgetItem
 
 

--- a/napari_aicsimageio/core.py
+++ b/napari_aicsimageio/core.py
@@ -85,7 +85,7 @@ def _get_scenes(img: AICSImage, in_memory: bool) -> None:
 
 
 # Function to get Metadata to provide with data
-def _get_meta(data, img) -> None:
+def _get_meta(data, img) -> Dict[str, Any]:
     meta = {}
     if DimensionNames.Channel in data.dims:
 

--- a/napari_aicsimageio/core.py
+++ b/napari_aicsimageio/core.py
@@ -100,7 +100,6 @@ def _get_scenes(img: AICSImage, in_memory: bool) -> None:
         viewer.add_image(data, name=scene_text, metadata=meta, scale=meta["scale"])
 
     list_widget.currentItemChanged.connect(open_scene)
-    return None
 
 
 # Function to get Metadata to provide with data
@@ -110,12 +109,15 @@ def _get_meta(data, img):
         # Construct basic metadata
         meta["name"] = data.coords[DimensionNames.Channel].data.tolist()
         meta["channel_axis"] = data.dims.index(DimensionNames.Channel)
+
     # Not multi-channel, use current scene as image name
     else:
         meta["name"] = img.reader.current_scene
+
     # Handle samples / RGB
     if DimensionNames.Samples in img.reader.dims.order:
         meta["rgb"] = True
+
     # Handle scales
     scale: List[float] = []
     for dim in img.reader.dims.order:
@@ -127,9 +129,11 @@ def _get_meta(data, img):
             scale_val = getattr(img.physical_pixel_sizes, dim)
             if scale_val is not None:
                 scale.append(scale_val)
+
     # Apply scales
     if len(scale) > 0:
         meta["scale"] = tuple(scale)
+
     # Apply all other metadata
     meta["metadata"] = {"ome_types": img.metadata}
 

--- a/napari_aicsimageio/core.py
+++ b/napari_aicsimageio/core.py
@@ -8,7 +8,6 @@ import xarray as xr
 from aicsimageio import AICSImage, exceptions, types
 from aicsimageio.dimensions import DimensionNames
 from qtpy.QtWidgets import QListWidget
-from qtpy.QtCore import Qt
 from napari import Viewer
 
 ###############################################################################
@@ -21,9 +20,9 @@ ReaderFunction = Callable[[PathLike], List[LayerData]]
 # _get_viewer() function from https://github.com/napari/napari/issues/2202
 # To provide access to the napari viewer to make the dock widget
 # Copyright (c) 2021 Jonas Windhager
-# Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-# The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+# Licensed under MIT License
+
+
 def _get_viewer() -> Optional[Viewer]:
     import inspect
 
@@ -160,7 +159,8 @@ def reader_function(
         )
         # Launch the list widget
         _get_scenes(img, in_memory=in_memory)
-        # Return an empty LayerData list, because Layers will be handled via the widget. HT Jonas Windhager
+        # Return an empty LayerData list; ImgLayers will be handled via the widget.
+        # HT Jonas Windhager
         return [(None,)]
     else:
         data = _get_full_image_data(img, in_memory=in_memory)

--- a/napari_aicsimageio/in_memory.py
+++ b/napari_aicsimageio/in_memory.py
@@ -3,6 +3,7 @@
 
 from typing import Optional
 
+from napari.types import PathLike, ReaderFunction
 from napari_plugin_engine import napari_hook_implementation
 
 from . import core
@@ -11,5 +12,5 @@ from . import core
 
 
 @napari_hook_implementation
-def napari_get_reader(path: core.PathLike) -> Optional[core.ReaderFunction]:
+def napari_get_reader(path: PathLike) -> Optional[ReaderFunction]:
     return core.get_reader(path, in_memory=True)

--- a/napari_aicsimageio/out_of_memory.py
+++ b/napari_aicsimageio/out_of_memory.py
@@ -3,6 +3,7 @@
 
 from typing import Optional
 
+from napari.types import PathLike, ReaderFunction
 from napari_plugin_engine import napari_hook_implementation
 
 from . import core
@@ -11,5 +12,5 @@ from . import core
 
 
 @napari_hook_implementation
-def napari_get_reader(path: core.PathLike) -> Optional[core.ReaderFunction]:
+def napari_get_reader(path: PathLike) -> Optional[ReaderFunction]:
     return core.get_reader(path, in_memory=False)

--- a/napari_aicsimageio/tests/test_core.py
+++ b/napari_aicsimageio/tests/test_core.py
@@ -57,7 +57,7 @@ CZI_FILE = "variable_scene_shape_first_scene_pyramid.czi"
             {
                 "name": ["Gray", "Red", "Green", "Cyan"],
                 "channel_axis": 1,
-                "scale": (4.984719055966396, 4.984719055966396),
+                "scale": (0.20061311154598827, 0.20061311154598827),
             },
         ),
     ],

--- a/napari_aicsimageio/tests/test_core.py
+++ b/napari_aicsimageio/tests/test_core.py
@@ -2,9 +2,10 @@
 # -*- coding: utf-8 -*-
 
 from pathlib import Path
-from typing import Any, Dict, Tuple
+from typing import Any, Callable, Dict, Tuple
 
 import dask.array as da
+import napari
 import numpy as np
 import pytest
 
@@ -115,7 +116,7 @@ MULTISCENE_FILE = "s_3_t_1_c_3_z_5.czi"
     ],
 )
 def test_for_multiscene_widget(
-    make_napari_viewer,
+    make_napari_viewer: Callable[..., napari.Viewer],
     resources_dir: Path,
     filename: str,
     in_memory: bool,
@@ -135,19 +136,20 @@ def test_for_multiscene_widget(
     # Get reader
     reader = core.get_reader(path, in_memory)
 
-    # Call reader on path
-    reader(path)
+    if reader is not None:
+        # Call reader on path
+        reader(path)
 
-    # Check for list widget
-    assert len(viewer.window._dock_widgets) == nr_widgets
+        # Check for list widget
+        assert len(viewer.window._dock_widgets) == nr_widgets
 
-    if len(viewer.window._dock_widgets) != 0:
-        assert list(viewer.window._dock_widgets.keys())[0] == "Scene Selector"
-        viewer.window._dock_widgets["Scene Selector"].widget().setCurrentRow(1)
-        data = viewer.layers[0].data
-        assert isinstance(data.data, expected_dtype)  # type: ignore
-        assert data.shape == expected_shape  # type: ignore
-    else:
-        data, meta, _ = reader(path)[0]
-        assert isinstance(data, expected_dtype)  # type: ignore
-        assert data.shape == expected_shape  # type: ignore
+        if len(viewer.window._dock_widgets) != 0:
+            assert list(viewer.window._dock_widgets.keys())[0] == "Scene Selector"
+            viewer.window._dock_widgets["Scene Selector"].widget().setCurrentRow(1)
+            data = viewer.layers[0].data
+            assert isinstance(data.data, expected_dtype)  # type: ignore
+            assert data.shape == expected_shape  # type: ignore
+        else:
+            data, meta, _ = reader(path)[0]
+            assert isinstance(data, expected_dtype)  # type: ignore
+            assert data.shape == expected_shape  # type: ignore

--- a/napari_aicsimageio/tests/test_core.py
+++ b/napari_aicsimageio/tests/test_core.py
@@ -145,9 +145,9 @@ def test_for_multiscene_widget(
         assert list(viewer.window._dock_widgets.keys())[0] == "Scene Selector"
         viewer.window._dock_widgets["Scene Selector"].widget().setCurrentRow(1)
         data = viewer.layers[0].data
-        assert isinstance(data.data, expected_dtype)
-        assert data.shape == expected_shape
+        assert isinstance(data.data, expected_dtype)  # type: ignore
+        assert data.shape == expected_shape  # type: ignore
     else:
         data, meta, _ = reader(path)[0]
-        assert isinstance(data, expected_dtype)
-        assert data.shape == expected_shape
+        assert isinstance(data, expected_dtype)  # type: ignore
+        assert data.shape == expected_shape  # type: ignore

--- a/napari_aicsimageio/tests/test_core.py
+++ b/napari_aicsimageio/tests/test_core.py
@@ -110,7 +110,7 @@ MULTISCENE_FILE = "s_3_t_1_c_3_z_5.czi"
 @pytest.mark.parametrize(
     "filename, nr_widgets, expected_shape",
     [
-        (SINGLESCENE_FILE, 0, (325, 475)),
+        (SINGLESCENE_FILE, 0, (1, 325, 475)),
         (MULTISCENE_FILE, 1, (3, 5, 325, 475)),
     ],
 )
@@ -143,3 +143,11 @@ def test_for_multiscene_widget(
 
     if len(viewer.window._dock_widgets) != 0:
         assert list(viewer.window._dock_widgets.keys())[0] == "Scene Selector"
+        viewer.window._dock_widgets["Scene Selector"].widget().setCurrentRow(1)
+        data = viewer.layers[0].data
+        assert isinstance(data.data, expected_dtype)
+        assert data.shape == expected_shape
+    else:
+        data, meta, _ = reader(path)[0]
+        assert isinstance(data, expected_dtype)
+        assert data.shape == expected_shape

--- a/napari_aicsimageio/tests/test_core.py
+++ b/napari_aicsimageio/tests/test_core.py
@@ -122,7 +122,7 @@ def test_for_multiscene_widget(
     nr_widgets: int,
     expected_dtype: type,
     expected_shape: Tuple[int, ...],
-):
+) -> None:
     # Make a viewer
     viewer = make_napari_viewer()
     assert len(viewer.layers) == 0
@@ -141,5 +141,5 @@ def test_for_multiscene_widget(
     # Check for list widget
     assert len(viewer.window._dock_widgets) == nr_widgets
 
-    if len(viewer.window._dock_widgets) > 0:
+    if len(viewer.window._dock_widgets) != 0:
         assert list(viewer.window._dock_widgets.keys())[0] == "Scene Selector"

--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,7 @@ test_requirements = [
     "mypy>=0.800",
     "psutil>=5.7.0",
     "pytest>=5.4.3",
+    "pytest-qt",
     "pytest-cov>=2.9.0",
     "pytest-raises>=0.11",
     "quilt3~=3.4.0",

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ dev_requirements = [
 requirements = [
     "aicsimageio[all]~=4.0.2",
     "fsspec[http]",  # no version pin, we pull from aicsimageio
-    "napari~=0.4.10",
+    "napari[all]~=0.4.11",
     "napari_plugin_engine~=0.1.4",
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ dev_requirements = [
 ]
 
 requirements = [
-    "aicsimageio[all]~=4.0.2",
+    "aicsimageio[all]~=4.1.0",
     "fsspec[http]",  # no version pin, we pull from aicsimageio
     "napari[all]~=0.4.11",
     "napari_plugin_engine~=0.1.4",


### PR DESCRIPTION
This PR adds support for selecting scenes from multi-scene files (such as LIF, CZI).
When a multi-scene files is opened or drag-n-dropped, a list widget opens on the right with all the scenes. Selecting a scene opens the scene in an image layer.

https://user-images.githubusercontent.com/76622105/133318735-1b192099-4b81-4cae-996e-1a22c7c3104c.mov

Some commentary:
1) Thank you so much for the guide for contributing, really helped me get over the fear of getting started! Alas, I could not get the `make build` testing suite work, due to pip/architecture issues (M1 arm64 Mac).
2) The solution to the issue of multiple scenes in this plugin wasn't as simple as just implementing a list widget (see for example: https://gist.github.com/psobolewskiPhD/2890e50504224533c46ee1d1d482ea81) This is because of the nature of the `reader` plugin type. Essentially, `reader` plugins should deal with I/O and not UI. They don't have access to the Viewer. See this issue https://github.com/napari/napari/issues/2202 by @jwindhager
3) @jwindhager did come up with a clever solution, but it can be considered a kludge. I'm not sure that this solution will be `acceptable` for such a flagship napari plugin—which I totally understand—but I went ahead and implemented that solution here.
4) For my colleagues and myself, the feature works well & very intuitively, whether you drag-n-drop or use File>Open. I tested every file in test/resources and I've been using it for a few days for my own files. Single scene? Opens as before. Many scenes? Widget and the user selects. Importantly, you can select->open->process*->repeat with new scene. This is actually really nice! We typically work with Leica LIF and ImageJ/Fiji. There the options are Bioformats, which imports, but requires scene selection in advance, via modal dialog, so you can't select as you go. Alternately, ReadMyLIFs permits this, as it's non-modal but it's *very slow* to read/process all the scenes initially (especially once you get into 100s of MB). This plugin solution with napari and xarray/dask is a revelation and a real improvement. Non-modal, instantaneous, easy to understand—especially once `readlif` new release provides access to improved scene names.
5) Testing is an issue? Because for a multiple scene image the plugin never really finished or returns anything, just creates the widget. I'm not sure how to select an item to complete a test without user interaction. I think it may be possible with `.setCurrentRow()`

* processing some images directly doesn't always work for LIF, depending on the plugin, due to https://github.com/AllenCellModeling/napari-aicsimageio/issues/24 but pyCLesperanto for example does work most of the time.


**Pull request recommendations:**
- [x] Name your pull request _your-development-type/short-description_. Ex: _feature/read-tiff-files_
- [ ] Link to any relevant issue in the PR description. Ex: _Resolves [gh-12], adds tiff file format support_: **N/A**
- [x] Provide context of changes.
- [ ] Provide relevant tests for your feature or bug fix. **Not sure how, see nr 5 above**
- [ ] Provide or update documentation for any feature added by your pull request. **Not sure how, but totally willing to write something/make a demo**

