### PR TITLE
admin/make-script-for-downloading-test-resource-use-cache

### DIFF
--- a/scripts/download_test_resources.py
+++ b/scripts/download_test_resources.py
@@ -79,14 +79,13 @@ def download_test_resources(args: Args):
         log.info(f"Downloading test resources using top hash: {top_hash}")
 
         # Get quilt package
-        package = Package.browse(
+        Package.install(
             "aicsimageio/test_resources",
             "s3://aics-modeling-packages-test-resources",
+            dest=resources_dir,
             top_hash=top_hash,
+            path="resources",
         )
-
-        # Download
-        package["resources"].fetch(resources_dir)
 
         log.info(f"Completed package download.")
 


### PR DESCRIPTION
**Pull request recommendations:**
- [x] Name your pull request _your-development-type/short-description_. Ex: _feature/read-tiff-files_
- [x] Link to any relevant issue in the PR description. Ex: _Resolves [gh-12], adds tiff file format support_

related to https://github.com/AllenCellModeling/napari-aicsimageio/issues/23
- [x] Provide context of changes.

Makes script for downloading use [`install()`](https://docs.quiltdata.com/api-reference/package#Package.install) instead of [`fetch()`](https://docs.quiltdata.com/api-reference/package#Package.fetch). `install()` uses cache so already downloaded files won't be re-downloaded in case of re-running script after network failure.

- [ ] Provide relevant tests for your feature or bug fix.
- [ ] Provide or update documentation for any feature added by your pull request.

Thanks for contributing!
