### PR TITLE
bugfix/squeeze-extra-dims

### DIFF
--- a/napari_aicsimageio/core.py
+++ b/napari_aicsimageio/core.py
@@ -50,9 +50,9 @@ def _get_full_image_data(
             )
 
     if in_memory:
-        return img.reader.xarray_data
+        return img.reader.xarray_data.squeeze()
 
-    return img.reader.xarray_dask_data
+    return img.reader.xarray_dask_data.squeeze()
 
 
 # Function to get Metadata to provide with data

--- a/napari_aicsimageio/core.py
+++ b/napari_aicsimageio/core.py
@@ -38,9 +38,9 @@ def _get_full_image_data(
     if DimensionNames.MosaicTile in img.reader.dims.order:
         try:
             if in_memory:
-                return img.reader.mosaic_xarray_data
+                return img.reader.mosaic_xarray_data.squeeze()
 
-            return img.reader.mosaic_xarray_dask_data
+            return img.reader.mosaic_xarray_dask_data.squeeze()
 
         # Catch reader does not support tile stitching
         except NotImplementedError:

--- a/napari_aicsimageio/tests/test_core.py
+++ b/napari_aicsimageio/tests/test_core.py
@@ -50,7 +50,7 @@ CZI_FILE = "variable_scene_shape_first_scene_pyramid.czi"
         ),
         (
             OME_TIFF,
-            (1, 4, 65, 600, 900),
+            (4, 65, 600, 900),
             {
                 "name": [
                     "0 :: Image:0 :: Bright_2",
@@ -58,13 +58,13 @@ CZI_FILE = "variable_scene_shape_first_scene_pyramid.czi"
                     "0 :: Image:0 :: CMDRP",
                     "0 :: Image:0 :: H3342",
                 ],
-                "channel_axis": 1,
+                "channel_axis": 0,
                 "scale": (0.29, 0.10833333333333332, 0.10833333333333332),
             },
         ),
         (
             LIF_FILE,
-            (1, 4, 1, 5622, 7666),
+            (4, 5622, 7666),
             {
                 "name": [
                     "0 :: TileScan_002 :: Gray",
@@ -72,7 +72,7 @@ CZI_FILE = "variable_scene_shape_first_scene_pyramid.czi"
                     "0 :: TileScan_002 :: Green",
                     "0 :: TileScan_002 :: Cyan",
                 ],
-                "channel_axis": 1,
+                "channel_axis": 0,
                 "scale": (0.20061311154598827, 0.20061311154598827),
             },
         ),
@@ -126,7 +126,7 @@ MULTISCENE_FILE = "s_3_t_1_c_3_z_5.czi"
 @pytest.mark.parametrize(
     "filename, expected_shape",
     [
-        (SINGLESCENE_FILE, (1, 325, 475)),
+        (SINGLESCENE_FILE, (325, 475)),
         (MULTISCENE_FILE, (3, 5, 325, 475)),
     ],
 )


### PR DESCRIPTION
**Pull request recommendations:**
- [x] Name your pull request _your-development-type/short-description_. Ex: _feature/read-tiff-files_
- [x] Link to any relevant issue in the PR description. Ex: _Resolves [gh-12], adds tiff file format support_

Resolves #24 

- [x] Provide context of changes.

Simple fix. xarray provides a squeeze function that also squeezes the dims out too

Tagging @psobolewskiPhD if you are happy with the shape changes reported in the tests please let me know. Will merge and release a new version on Monday.

- [x] Provide relevant tests for your feature or bug fix.
- [x] Provide or update documentation for any feature added by your pull request.

Thanks for contributing!
