### PR TITLE
bugfix/windows-build-main-yml-matrix

### DIFF
--- a/.github/workflows/build-main.yml
+++ b/.github/workflows/build-main.yml
@@ -20,7 +20,7 @@ jobs:
         os: [
           ubuntu-18.04,
           ubuntu-20.04,
-          # windows-latest,
+          windows-latest,
           macOS-10.15,
         ]
 


### PR DESCRIPTION
Sorry dropped the ball in https://github.com/AllenCellModeling/napari-aicsimageio/pull/41
Forgot to uncomment `windows-latest` in matrix section of build-main.yml

