### PR TITLE
admin/bump-min-aicsimageio-to-resolve-czi-physical-pixel-sizes

### DIFF
--- a/napari_aicsimageio/tests/test_core.py
+++ b/napari_aicsimageio/tests/test_core.py
@@ -45,7 +45,7 @@ CZI_FILE = "variable_scene_shape_first_scene_pyramid.czi"
                     "0 :: A1-A1 :: PGC",
                 ],
                 "channel_axis": 0,
-                "scale": (9.08210704883533, 9.08210704883533),
+                "scale": (0.908210704883533, 0.908210704883533),
             },
         ),
         (

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ dev_requirements = [
 ]
 
 requirements = [
-    "aicsimageio[all]>=4.6",
+    "aicsimageio[all]>=4.6.3",
     "fsspec[http]",  # no version pin, we pull from aicsimageio
     "napari>=0.4.11",
     "napari_plugin_engine>=0.1.4",


### PR DESCRIPTION
This resolves a build failure that occurred due to an upstream aicsimageio change with how physical pixel sizes are read from CZI metadata.

As a result the min aicsimageio is going up to a specific patch version of 4.6.3.