### PR TITLE
Use filename if single scene & no scene name

### DIFF
--- a/napari_aicsimageio/core.py
+++ b/napari_aicsimageio/core.py
@@ -62,21 +62,32 @@ def _get_full_image_data(
 
 
 # Function to get Metadata to provide with data
-def _get_meta(data: xr.DataArray, img: AICSImage) -> Dict[str, Any]:
+def _get_meta(path: "PathLike", data: xr.DataArray, img: AICSImage) -> Dict[str, Any]:
     meta: Dict[str, Any] = {}
     if DimensionNames.Channel in data.dims:
         # Construct basic metadata
-        channels_with_scene_index = [
-            f"{img.current_scene_index}{SCENE_LABEL_DELIMITER}"
-            f"{img.current_scene}{SCENE_LABEL_DELIMITER}{channel_name}"
-            for channel_name in data.coords[DimensionNames.Channel].data.tolist()
-        ]
+        # Use filename if single scene and no scene name is available
+        if len(img.scenes) == 1 and img.current_scene == "Image:0":
+            channels_with_scene_index = [
+                f"{Path(path).stem}{SCENE_LABEL_DELIMITER}{channel_name}"
+                for channel_name in data.coords[DimensionNames.Channel].data.tolist()
+            ]
+        else:
+            channels_with_scene_index = [
+                f"{img.current_scene_index}{SCENE_LABEL_DELIMITER}"
+                f"{img.current_scene}{SCENE_LABEL_DELIMITER}{channel_name}"
+                for channel_name in data.coords[DimensionNames.Channel].data.tolist()
+            ]
         meta["name"] = channels_with_scene_index
         meta["channel_axis"] = data.dims.index(DimensionNames.Channel)
 
     # Not multi-channel, use current scene as image name
     else:
-        meta["name"] = img.reader.current_scene
+        # use filename if single scene and no scene name is available
+        if len(img.scenes) == 1 and img.current_scene == "Image:0":
+            meta["name"] = Path(path).stem
+        else:
+            meta["name"] = img.reader.current_scene
 
     # Handle samples / RGB
     if DimensionNames.Samples in img.reader.dims.order:
@@ -242,7 +253,7 @@ def reader_function(
         return [(None,)]
     else:
         data = _get_full_image_data(img, in_memory=_in_memory)
-        meta = _get_meta(data, img)
+        meta = _get_meta(path, data, img)
         return [(data.data, meta, "image")]
 
 

--- a/napari_aicsimageio/core.py
+++ b/napari_aicsimageio/core.py
@@ -191,7 +191,7 @@ def _get_scenes(path: "PathLike", img: AICSImage, in_memory: bool) -> None:
         data = _get_full_image_data(img=img, in_memory=in_memory)
 
         # Get metadata and add to image
-        meta = _get_meta(data, img)
+        meta = _get_meta("", data, img)
 
         # Optionally clear layers
         if _widget_is_checked(CLEAR_LAYERS_ON_SELECT):

--- a/napari_aicsimageio/tests/test_core.py
+++ b/napari_aicsimageio/tests/test_core.py
@@ -37,8 +37,8 @@ CZI_FILE = "variable_scene_shape_first_scene_pyramid.czi"
 @pytest.mark.parametrize(
     "filename, expected_shape, expected_meta",
     [
-        (PNG_FILE, (800, 537, 4), {"name": "Image:0", "rgb": True}),
-        (GIF_FILE, (72, 268, 268, 4), {"name": "Image:0", "rgb": True}),
+        (PNG_FILE, (800, 537, 4), {"name": Path(PNG_FILE).stem, "rgb": True}),
+        (GIF_FILE, (72, 268, 268, 4), {"name": Path(GIF_FILE).stem, "rgb": True}),
         (
             CZI_FILE,
             (3, 6183, 7705),
@@ -57,10 +57,10 @@ CZI_FILE = "variable_scene_shape_first_scene_pyramid.czi"
             (4, 65, 600, 900),
             {
                 "name": [
-                    "0 :: Image:0 :: Bright_2",
-                    "0 :: Image:0 :: EGFP",
-                    "0 :: Image:0 :: CMDRP",
-                    "0 :: Image:0 :: H3342",
+                    f"{Path(OME_TIFF).stem} :: Bright_2",
+                    f"{Path(OME_TIFF).stem} :: EGFP",
+                    f"{Path(OME_TIFF).stem} :: CMDRP",
+                    f"{Path(OME_TIFF).stem} :: H3342",
                 ],
                 "channel_axis": 0,
                 "scale": (0.29, 0.10833333333333332, 0.10833333333333332),


### PR DESCRIPTION
This is a small tweak to adress the issue: 
https://github.com/AllenCellModeling/napari-aicsimageio/issues/57

For a single-scene image, the default layer name was using the default image ID: `Image:0`.
With this change, for single scene images the filename is used instead.
This matches the behavior of napari builtin readers for things like .jpg, .png, and single channel TIF. For multichannel, but still single scene, the filename is used as the root of the layer name, with the channel info appended, as previously.
Multiscene behavior remains unchanged.

**Pull request recommendations:**
- [x] Name your pull request _your-development-type/short-description_. Ex: _feature/read-tiff-files_
- [x] Link to any relevant issue in the PR description. Ex: _Resolves [gh-12], adds tiff file format support_
- [x] Provide context of changes.
- [x] Provide relevant tests for your feature or bug fix. *I adjusted the tests to check the relevant case*
- [ ] Provide or update documentation for any feature added by your pull request.

Edit: @MosGeo what do you think? Personally, I like it.