### PR TITLE
Bugfix: Fix napari-plugin-check version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,7 +25,7 @@ repos:
           - flake8-pyprojecttoml
 
   - repo: https://github.com/tlambert03/napari-plugin-checks
-    rev: v0.2.0
+    rev: v0.3.0
     hooks:
       - id: napari-plugin-checks
 


### PR DESCRIPTION
The `lint` step of CI workflows is failing with a TypeError.
This issue has been fixed by @tlambert03 upstream, see:
https://github.com/tlambert03/napari-plugin-checks/issues/7
Updating the version of `napari-plugin-check` should resolve it here.

**Pull request recommendations:**
- [x] Name your pull request _your-development-type/short-description_. Ex: _feature/read-tiff-files_
- [x] Link to any relevant issue in the PR description. Ex: _Resolves [gh-12], adds tiff file format support_
- [x] Provide context of changes.
- [ ] Provide relevant tests for your feature or bug fix.
- [ ] Provide or update documentation for any feature added by your pull request.

