### PR TITLE
Bugfix: Check the squeezed data for scale vals

### DIFF
--- a/napari_aicsimageio/core.py
+++ b/napari_aicsimageio/core.py
@@ -84,7 +84,8 @@ def _get_meta(data: xr.DataArray, img: AICSImage) -> Dict[str, Any]:
 
     # Handle scales
     scale: List[float] = []
-    for dim in img.reader.dims.order:
+    # check the dims of the squeezed array for scale values
+    for dim in data.dims:
         if dim in [
             DimensionNames.SpatialX,
             DimensionNames.SpatialY,


### PR DESCRIPTION
This is a fix for: https://github.com/AllenCellModeling/napari-aicsimageio/issues/54
(see also: https://forum.image.sc/t/napari-napari-aicsimageio-faild-to-open-ome-tiff/68942/2?u=sebi06)
Basically, when setting the scale metadata for napari, the original `img` was used, even if a singleton was squeezed. If the singleton happened to have a valid scale value, this was passed to napari, even though the dimension wasn't.
The fix here checks the physical `dims` of the actual squeezed xarray `data` for scale data, so if a dim was squeezed, but had valid scale, it will be ignored.

**Pull request recommendations:**
- [x] Name your pull request _your-development-type/short-description_. Ex: _feature/read-tiff-files_
- [x] Link to any relevant issue in the PR description. Ex: _Resolves [gh-12], adds tiff file format support_
- [x] Provide context of changes.
- [ ] Provide relevant tests for your feature or bug fix. *I think the file from @sebi06 would have failed tests previously, because the read scale meta (z, y, x) would not match expected (y, x). And obviously napari doesn't like the layer data that is passed.*
- [ ] Provide or update documentation for any feature added by your pull request.
