### PR TITLE
Feature: a widget for setting Reader settings

### DIFF
--- a/napari_aicsimageio/_settings_widget.py
+++ b/napari_aicsimageio/_settings_widget.py
@@ -1,0 +1,18 @@
+from typing import List
+
+import napari
+from magicgui import magic_factory
+
+
+@magic_factory(
+    delimiter={"label": "Delimiter in scene labels:"},
+    in_mem_size={"label": "Threshold for out-of-memory loading (GB)"},
+    frac_mem_size={"label": "Threshold for out-of-memory loading (% free memory):"},
+    call_button="Set Reader Settings",
+)
+def set_settings(delimiter: str = " :: ", in_mem_size: float = 4, frac_mem_size: int = 30) -> None:
+    import napari_aicsimageio.core
+
+    napari_aicsimageio.core.SCENE_LABEL_DELIMITER = delimiter
+    napari_aicsimageio.core.IN_MEM_THRESHOLD_SIZE_BYTES = in_mem_size * 1e9
+    napari_aicsimageio.core.IN_MEM_THRESHOLD_PERCENT = frac_mem_size / 100

--- a/napari_aicsimageio/_settings_widget.py
+++ b/napari_aicsimageio/_settings_widget.py
@@ -1,6 +1,3 @@
-from typing import List
-
-import napari
 from magicgui import magic_factory
 
 
@@ -10,7 +7,9 @@ from magicgui import magic_factory
     frac_mem_size={"label": "Threshold for out-of-memory loading (% free memory):"},
     call_button="Set Reader Settings",
 )
-def set_settings(delimiter: str = " :: ", in_mem_size: float = 4, frac_mem_size: int = 30) -> None:
+def set_settings(
+    delimiter: str = " :: ", in_mem_size: float = 4, frac_mem_size: int = 30
+) -> None:
     import napari_aicsimageio.core
 
     napari_aicsimageio.core.SCENE_LABEL_DELIMITER = delimiter

--- a/napari_aicsimageio/_settings_widget.py
+++ b/napari_aicsimageio/_settings_widget.py
@@ -1,18 +1,25 @@
+import napari
 from magicgui import magic_factory
+
+import napari_aicsimageio.core
 
 
 @magic_factory(
     delimiter={"label": "Delimiter in scene labels:"},
     in_mem_size={"label": "Threshold for out-of-memory loading (GB)"},
-    frac_mem_size={"label": \
-        "Threshold for out-of-memory loading (% free memory):"},
-    call_button="Set Reader Settings",
+    frac_mem_size={"label": "Threshold for out-of-memory loading (% free memory):"},
+    call_button="Set Reader Settings and Close Widget",
 )
 def set_settings(
-    delimiter: str = " :: ", in_mem_size: float = 4, frac_mem_size: int = 30
+    napari_viewer: napari.Viewer,
+    delimiter: str = napari_aicsimageio.core.SCENE_LABEL_DELIMITER,
+    in_mem_size: float = napari_aicsimageio.core.IN_MEM_THRESHOLD_SIZE_BYTES / 1e9,
+    frac_mem_size: int = int(napari_aicsimageio.core.IN_MEM_THRESHOLD_PERCENT * 100),
 ) -> None:
-    import napari_aicsimageio.core
 
     napari_aicsimageio.core.SCENE_LABEL_DELIMITER = delimiter
     napari_aicsimageio.core.IN_MEM_THRESHOLD_SIZE_BYTES = in_mem_size * 1e9
     napari_aicsimageio.core.IN_MEM_THRESHOLD_PERCENT = frac_mem_size / 100
+
+    viewer = napari_viewer
+    viewer.window.remove_dock_widget(set_settings.native)

--- a/napari_aicsimageio/_settings_widget.py
+++ b/napari_aicsimageio/_settings_widget.py
@@ -9,6 +9,7 @@ import napari_aicsimageio.core
     in_mem_size={"label": "Threshold for out-of-memory loading (GB)"},
     frac_mem_size={"label": "Threshold for out-of-memory loading (% free memory):"},
     call_button="Set Reader Settings and Close Widget",
+    persist=True,
 )
 def set_settings(
     napari_viewer: napari.Viewer,

--- a/napari_aicsimageio/_settings_widget.py
+++ b/napari_aicsimageio/_settings_widget.py
@@ -4,7 +4,8 @@ from magicgui import magic_factory
 @magic_factory(
     delimiter={"label": "Delimiter in scene labels:"},
     in_mem_size={"label": "Threshold for out-of-memory loading (GB)"},
-    frac_mem_size={"label": "Threshold for out-of-memory loading (% free memory):"},
+    frac_mem_size={"label": \
+        "Threshold for out-of-memory loading (% free memory):"},
     call_button="Set Reader Settings",
 )
 def set_settings(

--- a/napari_aicsimageio/_settings_widget.py
+++ b/napari_aicsimageio/_settings_widget.py
@@ -7,11 +7,18 @@ import napari_aicsimageio.core
 @magic_factory(
     delimiter={"label": "Delimiter in scene labels:"},
     in_mem_size={"label": "Threshold for out-of-memory loading (GB)"},
-    frac_mem_size={"label": "Threshold for out-of-memory loading (% free memory):"},
-    call_button="Set Reader Settings and Close Widget",
+    frac_mem_size={
+        "label": "Threshold for out-of-memory loading (<small>% free memory</small>):"
+    },
+    call_button="Apply Reader Settings and Close Widget",
+    info_label=dict(
+        widget_type="Label",
+        label="<h4>For each napari session, to use the settings:<br>press the Apply button!</h4>",
+    ),
     persist=True,
 )
 def set_settings(
+    info_label: str,
     napari_viewer: napari.Viewer,
     delimiter: str = napari_aicsimageio.core.SCENE_LABEL_DELIMITER,
     in_mem_size: float = napari_aicsimageio.core.IN_MEM_THRESHOLD_SIZE_BYTES / 1e9,

--- a/napari_aicsimageio/napari.yaml
+++ b/napari_aicsimageio/napari.yaml
@@ -5,6 +5,13 @@ contributions:
   - id: napari-aicsimageio.get_reader
     title: Get AICSImageIO Reader
     python_name: napari_aicsimageio.core:get_reader
+  - id: napari-aicsimageio.settings_widget
+    title: Open AICSImageIO Reader Settings
+    python_name: napari_aicsimageio._settings_widget:set_settings
+
+  widgets:
+  - command: napari-aicsimageio.settings_widget
+    display_name: AICSImageIO Reader Settings
   readers:
   - command: napari-aicsimageio.get_reader
     filename_patterns: [


### PR DESCRIPTION
This PR adds a second `contribution` to the plugin: a dock widget.
The dock widget allows for setting some parameters that are used by the reader.
The aim is to address #29 but could be extend to #34 
This is a WIP, at present it looks like:
<img width="1202" alt="image" src="https://user-images.githubusercontent.com/76622105/198850616-bbea75ac-82d4-4497-92c8-f9d9abd82162.png">

Things to consider:
1. adding a checkbox to just override the thresholds and load out of memory. This could be accomplished by adding `IN_MEMORY` to `core.py` and setting that as the default for `in_memory` for `reader_function`
2. to address #34 should add `AUTOLOAD_FIRST_SCENE` to `core.py` and modify `_get_scenes` to load the first scene based on this boolean setting.
3. For the `Delimiter`, should the white spaces be set by the user or appended to the string provided by the user?
~~4. I'd like the widget to close itself when the user confirms/sets the settings, but this is still WIP—not sure how to accomplish it.~~ *DONE*
5. Persistence of settings: should they be autoloaded in some fashion when loading the reader?
6. Do we need a button to reset back to the original defaults?

Feedback very welcome!
CC: @lambda-science


