### PR TITLE
Bugfix: make Scene Management widget closable (settings persist)

### DIFF
--- a/napari_aicsimageio/core.py
+++ b/napari_aicsimageio/core.py
@@ -149,13 +149,13 @@ def _get_scenes(path: "PathLike", img: AICSImage, in_memory: bool) -> None:
     # Get napari viewer from current process
     viewer = napari.current_viewer()
     scene_settings_widget = set_scene_settings()
-
+    scene_settings_widget.max_height = 200
     
     # Add a checkbox widget if not present
     if AICSIMAGEIO_CHOICES not in viewer.window._dock_widgets:
         viewer.window.add_dock_widget(scene_settings_widget,
-                                      area = 'right', 
-                                      name = AICSIMAGEIO_CHOICES
+                                      area = 'right',
+                                      name = AICSIMAGEIO_CHOICES,
                                     )
 
 

--- a/napari_aicsimageio/core.py
+++ b/napari_aicsimageio/core.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from functools import partial
 from logging import getLogger
+from magicgui import magic_factory
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
@@ -26,8 +27,8 @@ logger = getLogger(__name__)
 ###############################################################################
 
 AICSIMAGEIO_CHOICES = "AICSImageIO Scene Management"
-CLEAR_LAYERS_ON_SELECT = "Clear All Layers on New Scene Selection"
-UNPACK_CHANNELS_TO_LAYERS = "Unpack Channels as Layers"
+CLEAR_LAYERS_ON_SELECT = False
+UNPACK_CHANNELS_TO_LAYERS = False
 
 SCENE_LABEL_DELIMITER = " :: "
 
@@ -121,20 +122,24 @@ def _get_meta(path: "PathLike", data: xr.DataArray, img: AICSImage) -> Dict[str,
     return meta
 
 
-def _widget_is_checked(widget_name: str) -> bool:
-    import napari
-
-    # Get napari viewer from current process
-    viewer = napari.current_viewer()
-
-    # Get scene management widget
-    scene_manager_choices_widget = viewer.window._dock_widgets[AICSIMAGEIO_CHOICES]
-    for child in scene_manager_choices_widget.widget().children():
-        if isinstance(child, QCheckBox):
-            if child.text() == widget_name:
-                return child.isChecked()
-
-    return False
+@magic_factory(call_button="Apply Scene Settings",
+    info_label=dict(
+         widget_type="Label",
+         label="<h4>For each napari session, \
+             <br>to use the settings: \
+             <br>press the Apply button!</h4>",
+     ),
+     persist=True,
+ )
+def set_scene_settings(
+    info_label: str,
+    clear_layers: bool = CLEAR_LAYERS_ON_SELECT,
+    unpack_channels: bool = UNPACK_CHANNELS_TO_LAYERS,
+    ) -> None:
+    global CLEAR_LAYERS_ON_SELECT
+    CLEAR_LAYERS_ON_SELECT = clear_layers
+    global UNPACK_CHANNELS_TO_LAYERS
+    UNPACK_CHANNELS_TO_LAYERS = unpack_channels
 
 
 # Function to handle multi-scene files.
@@ -143,30 +148,16 @@ def _get_scenes(path: "PathLike", img: AICSImage, in_memory: bool) -> None:
 
     # Get napari viewer from current process
     viewer = napari.current_viewer()
+    scene_settings_widget = set_scene_settings()
 
+    
     # Add a checkbox widget if not present
     if AICSIMAGEIO_CHOICES not in viewer.window._dock_widgets:
-        # Create a checkbox widget to set "Clear On Scene Select" or not
-        scene_clear_checkbox = QCheckBox(CLEAR_LAYERS_ON_SELECT)
-        scene_clear_checkbox.setChecked(False)
+        viewer.window.add_dock_widget(scene_settings_widget,
+                                      area = 'right', 
+                                      name = AICSIMAGEIO_CHOICES
+                                    )
 
-        # Create a checkbox widget to set "Unpack Channels" or not
-        channel_unpack_checkbox = QCheckBox(UNPACK_CHANNELS_TO_LAYERS)
-        channel_unpack_checkbox.setChecked(False)
-
-        # Add all scene management state to a single box
-        scene_manager_group = QGroupBox()
-        scene_manager_group_layout = QVBoxLayout()
-        scene_manager_group_layout.addWidget(scene_clear_checkbox)
-        scene_manager_group_layout.addWidget(channel_unpack_checkbox)
-        scene_manager_group.setLayout(scene_manager_group_layout)
-        scene_manager_group.setFixedHeight(100)
-
-        viewer.window.add_dock_widget(
-            scene_manager_group,
-            area="right",
-            name=AICSIMAGEIO_CHOICES,
-        )
 
     # Create the list widget and populate with the ids & scenes in the file
     list_widget = QListWidget()
@@ -195,11 +186,11 @@ def _get_scenes(path: "PathLike", img: AICSImage, in_memory: bool) -> None:
         meta = _get_meta("", data, img)
 
         # Optionally clear layers
-        if _widget_is_checked(CLEAR_LAYERS_ON_SELECT):
+        if CLEAR_LAYERS_ON_SELECT:
             viewer.layers.clear()
 
         # Optionally remove channel axis
-        if not _widget_is_checked(UNPACK_CHANNELS_TO_LAYERS):
+        if not UNPACK_CHANNELS_TO_LAYERS:
             meta["name"] = scene_text
             meta.pop("channel_axis", None)
 


### PR DESCRIPTION
This PR aims to fix https://github.com/AllenCellModeling/napari-aicsimageio/issues/66
When a multi-scene file is loaded, two widgets are created.
One has two checkboxes, the other has the scenes to load.
The status of the first widget (the checkboxes) is checked when the scenes are to be loaded. **As a result, if that widget is closed an error is raised.**

In this PR, the first widget instead sets global variables, so it need not be open. 
If the settings are applied, then the widget can be closed and scenes can be loaded.
(this permits more vertical space for scene selection, particularly on smaller screens—like mine!)
Additionally, the previous values are persisted thanks to magicgui.


