### PR TITLE
bugfix/use-data.data-in-open_scene

### DIFF
--- a/napari_aicsimageio/core.py
+++ b/napari_aicsimageio/core.py
@@ -203,7 +203,7 @@ def _get_scenes(path: "PathLike", img: AICSImage, in_memory: bool) -> None:
             meta["name"] = scene_text
             meta.pop("channel_axis", None)
 
-        viewer.add_image(data, **meta)
+        viewer.add_image(data.data, **meta)
 
     list_widget.currentItemChanged.connect(open_scene)  # type: ignore
 

--- a/napari_aicsimageio/tests/test_core.py
+++ b/napari_aicsimageio/tests/test_core.py
@@ -169,7 +169,7 @@ def test_for_multiscene_widget(
                 1
             )
             data = viewer.layers[0].data
-            assert isinstance(data.data, expected_dtype)
+            assert isinstance(data, expected_dtype)
             assert data.shape == expected_shape
         else:
             data, _, _ = reader(path)[0]


### PR DESCRIPTION
## Description

If a single scene image is opened, the return is `data.data` which is just the array from the xarray.DataArray
If a multi scene file is opened (using the scene selector widget) the return from the `open_scene` is an image layer with `data`, the actual xarray.DataArray. 

Napari actually handles this just fine, but some downstream plugins do not, expecting numpy arrays (e.g. napari-matplotlib). This is sort of something they should be better at handling, perhaps using `np.asarray`,  but at the same time I feel like these two should work the same?
I think this plugin should/could be the default beyond builtins, so probably standardizing on the array and not xarray.DataArray is best, so probably `data.data` is preferred as a default behavior. 
As the person partially responsible for the scene selector, I think this was an oversight on my part...

So in this PR I just make that small change and update the test accordingly.
At the same time, I can understand just returning the xarray.DataArray. But then for consistency, the single scene should just return `data`.

**Pull request recommendations:**
- [x] Name your pull request _your-development-type/short-description_. Ex: _feature/read-tiff-files_
- [ ] Link to any relevant issue in the PR description. Ex: _Resolves [gh-12], adds tiff file format support_
- [x] Provide context of changes.
- [x] Provide relevant tests for your feature or bug fix: I updated the test for the change.
- [ ] Provide or update documentation for any feature added by your pull request.

Thanks for contributing!
