### PR TITLE
Admin/bump-isort-version-to-fix-lint-CI-failure

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 repos:
 
   - repo: https://github.com/PyCQA/isort
-    rev: 5.10.1
+    rev: 5.12.0
     hooks:
       - id: isort
 


### PR DESCRIPTION

Linting on CI is failing, see for example: https://github.com/AllenCellModeling/napari-aicsimageio/actions/runs/4365533603/jobs/7634287862#step:5:32

The error refers to `RuntimeError: The Poetry configuration is invalid:`
Googling, indicates it's an `isort` issue:
https://github.com/PyCQA/isort/issues/2077

The latest release 5.12.0 has a fix released:
https://github.com/PyCQA/isort/releases/tag/5.12.0

This PR bumps the version in pre-commit-config.yaml

**Pull request recommendations:**
- [x] Name your pull request _your-development-type/short-description_. Ex: _feature/read-tiff-files_
- [x] Link to any relevant issue in the PR description. Ex: _Resolves [gh-12], adds tiff file format support_
- [x] Provide context of changes.
- [ ] Provide relevant tests for your feature or bug fix.
- [ ] Provide or update documentation for any feature added by your pull request.

Thanks for contributing!
