### PR TITLE
feature/add-checkbox-for-mosaic-merge

### DIFF
--- a/napari_aicsimageio/core.py
+++ b/napari_aicsimageio/core.py
@@ -198,7 +198,9 @@ def _get_scenes(path: "PathLike", img: AICSImage, in_memory: bool) -> None:
         img.set_scene(scene_index)
         # check whether to mosaic merge or not
         if _widget_is_checked(DONT_MERGE_MOSAICS):
-            data = _get_full_image_data(img=img, in_memory=in_memory, reconstruct_mosaic=False)
+            data = _get_full_image_data(
+                img=img, in_memory=in_memory, reconstruct_mosaic=False
+            )
         else:
             data = _get_full_image_data(img=img, in_memory=in_memory)
 

--- a/napari_aicsimageio/core.py
+++ b/napari_aicsimageio/core.py
@@ -157,15 +157,15 @@ def _get_scenes(path: "PathLike", img: AICSImage, in_memory: bool) -> None:
         channel_unpack_checkbox.setChecked(False)
 
         # Create a checkbox widget to set "Mosaic Merge" or not
-        mosaic_merge_checkbox = QCheckBox(DONT_MERGE_MOSAICS)
-        mosaic_merge_checkbox.setChecked(False)
+        dont_merge_mosaics_checkbox = QCheckBox(DONT_MERGE_MOSAICS)
+        dont_merge_mosaics_checkbox.setChecked(False)
 
         # Add all scene management state to a single box
         scene_manager_group = QGroupBox()
         scene_manager_group_layout = QVBoxLayout()
         scene_manager_group_layout.addWidget(scene_clear_checkbox)
         scene_manager_group_layout.addWidget(channel_unpack_checkbox)
-        scene_manager_group_layout.addWidget(mosaic_merge_checkbox)
+        scene_manager_group_layout.addWidget(dont_merge_mosaics_checkbox)
         scene_manager_group.setLayout(scene_manager_group_layout)
         scene_manager_group.setFixedHeight(100)
 

--- a/napari_aicsimageio/core.py
+++ b/napari_aicsimageio/core.py
@@ -28,6 +28,7 @@ logger = getLogger(__name__)
 AICSIMAGEIO_CHOICES = "AICSImageIO Scene Management"
 CLEAR_LAYERS_ON_SELECT = "Clear All Layers on New Scene Selection"
 UNPACK_CHANNELS_TO_LAYERS = "Unpack Channels as Layers"
+DONT_MERGE_MOSAICS = "Don't Merge Mosaics"
 
 SCENE_LABEL_DELIMITER = " :: "
 
@@ -40,8 +41,9 @@ IN_MEM_THRESHOLD_SIZE_BYTES = 4e9  # 4GB
 def _get_full_image_data(
     img: AICSImage,
     in_memory: bool,
+    reconstruct_mosaic: bool = True,
 ) -> xr.DataArray:
-    if DimensionNames.MosaicTile in img.reader.dims.order:
+    if DimensionNames.MosaicTile in img.reader.dims.order and reconstruct_mosaic:
         try:
             if in_memory:
                 return img.reader.mosaic_xarray_data.squeeze()
@@ -154,11 +156,16 @@ def _get_scenes(path: "PathLike", img: AICSImage, in_memory: bool) -> None:
         channel_unpack_checkbox = QCheckBox(UNPACK_CHANNELS_TO_LAYERS)
         channel_unpack_checkbox.setChecked(False)
 
+        # Create a checkbox widget to set "Mosaic Merge" or not
+        mosaic_merge_checkbox = QCheckBox(DONT_MERGE_MOSAICS)
+        mosaic_merge_checkbox.setChecked(False)
+
         # Add all scene management state to a single box
         scene_manager_group = QGroupBox()
         scene_manager_group_layout = QVBoxLayout()
         scene_manager_group_layout.addWidget(scene_clear_checkbox)
         scene_manager_group_layout.addWidget(channel_unpack_checkbox)
+        scene_manager_group_layout.addWidget(mosaic_merge_checkbox)
         scene_manager_group.setLayout(scene_manager_group_layout)
         scene_manager_group.setFixedHeight(100)
 
@@ -189,7 +196,11 @@ def _get_scenes(path: "PathLike", img: AICSImage, in_memory: bool) -> None:
 
         # Update scene on image and get data
         img.set_scene(scene_index)
-        data = _get_full_image_data(img=img, in_memory=in_memory)
+        # check whether to mosaic merge or not
+        if _widget_is_checked(DONT_MERGE_MOSAICS):
+            data = _get_full_image_data(img=img, in_memory=in_memory, reconstruct_mosaic=False)
+        else:
+            data = _get_full_image_data(img=img, in_memory=in_memory)
 
         # Get metadata and add to image
         meta = _get_meta("", data, img)


### PR DESCRIPTION
By default, the AICSImage object will stitch mosaic tiles together for LIF and CZI.
This can be nice when it works, but it isn't always (e.g. https://github.com/AllenCellModeling/aicsimageio/issues/278).
Also, in my use case I frequently have experiments that use tiles that are not adjacent, but instead scattered. Then merging really makes no sense.

As a result, I've added an extra checkbox to the `AICSImageIO Scene Management` widget, to allow an override of the default behavior.
Note that for a single-scene image there currently isn't a way to override the default behavior.

**Pull request recommendations:**
- [x] Name your pull request _your-development-type/short-description_. Ex: _feature/read-tiff-files_
- [x] Link to any relevant issue in the PR description. Ex: _Resolves [gh-12], adds tiff file format support_
- [x] Provide context of changes.
- [ ] Provide relevant tests for your feature or bug fix.

I've tested locally and the checkbox works as advertised. I have multi-scene multi-tile LIF images, but they are very large, so using them for tests on CI seems like a bad idea. I won't be able to image something simpler for a while. Note: The current checkboxes aren't tested either!

- [ ] Provide or update documentation for any feature added by your pull request.
N/A

