### PR TITLE
Documentation/Clarify-bioformats-requires-java-and-mvn

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ AICSImageIO bindings for napari
     -   `DV` (DeltaVision)
     -   Any formats supported by [aicsimageio](https://github.com/AllenCellModeling/aicsimageio)
     -   Any formats supported by [bioformats](https://github.com/tlambert03/bioformats_jar)
+(Note: requires `java` and `mvn` executables)
         -   `SLD` (Slidebook)
         -   `SVS` (Aperio)
         -   [Full List](https://docs.openmicroscopy.org/bio-formats/6.5.1/supported-formats.html)
@@ -35,6 +36,11 @@ _While upstream `aicsimageio` is released under BSD-3 license, this plugin is re
 
 **Stable Release:** `pip install napari-aicsimageio` or `conda install napari-aicsimageio -c conda-forge`<br>
 **Development Head:** `pip install git+https://github.com/AllenCellModeling/napari-aicsimageio.git`
+
+> **Warning**  
+> The `bioformats` reader requires `java` and `mvn` executables, which cannot be pip installed.
+> As a result, it's simplest to install it from conda-forge, ensuring both are also installed:  
+> `conda install -c conda-forge bioformats_jar`
 
 ### Reading Mode Threshold
 


### PR DESCRIPTION
This PR adds updates the README regarding the `bioformats` reader requiring `java` and `mvn`. Then in installation section, it also strongly suggests using conda-forge to install bioformats_jar.

See discussion here: https://github.com/AllenCellModeling/napari-aicsimageio/issues/46#issuecomment-1462895156

This should resolve that issue—I'm not sure how better to address it anyways.


**Pull request recommendations:**
- [x] Name your pull request _your-development-type/short-description_. Ex: _feature/read-tiff-files_
- [x] Link to any relevant issue in the PR description. Ex: _Resolves [gh-12], adds tiff file format support_
- [x] Provide context of changes.
- [ ] Provide relevant tests for your feature or bug fix.
- [ ] Provide or update documentation for any feature added by your pull request.

Thanks for contributing!
